### PR TITLE
Use the right UIDs

### DIFF
--- a/app/controllers/dropbox/webhooks_controller.rb
+++ b/app/controllers/dropbox/webhooks_controller.rb
@@ -10,7 +10,7 @@ module Dropbox
       Rails.logger.info json
 
       payload = JSON.load json
-      payload["delta"]["users"].each do |uid|
+      payload["list_folder"]["accounts"].each do |uid|
         Tasks::BackgroundTask.new(Tasks::UpdateBulletins.new).perform(uid.to_s)
       end
 


### PR DESCRIPTION
Dropbox provides this input:

    {
      "list_folder": {
        "accounts": [ "dbid:AADswEU5YBL_5yQSwgGsBnKNqWsTDh-YUFQ" ]
      },
      "delta": {
        "users": [ 10974355 ]
      }
    }

This app needs the "dbid:..." values. At some point in the past, the delta.users values must have had dbids, but now they're numeric. I'm surprised that these kept working until now, since the dropbox's v2 API was when the ids changed format. 

This change makes the webhook endpoint use the right IDs, so that we can get the right bulletins.